### PR TITLE
Updated index.js file for isInternational param

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,10 @@ class SendOtp {
     /**
      * Creates a new SendOtp instance
      * @param {string} authKey Authentication key
+     * @param {boolean} isInternational send true if it is an international message, otherwise false.
      * @param {string, optional} messageTemplate
      */
-    constructor(authKey, messageTemplate) {
+    constructor(authKey, isInternational, messageTemplate) {
         this.authKey = authKey;
         if(messageTemplate){
             this.messageTemplate = messageTemplate;
@@ -17,6 +18,7 @@ class SendOtp {
             this.messageTemplate = "Your otp is {{otp}}. Please do not share it with anybody";
         }
         this.otp_expiry = 1440; //1 Day =1440 minutes
+        this.isInternational = isInternational
     }
 
     /**
@@ -63,6 +65,10 @@ class SendOtp {
                 otp: otp,
                 otp_expiry: this.otp_expiry
             };
+
+        if (this.isInternational) {
+            args.country=0
+        }
         return SendOtp.doRequest('get', "sendotp.php", args, callback);
     }
 


### PR DESCRIPTION
Added isInternational param to the constructor, pass it true if the OTP SMS is going to be an international one, false otherwise.
The API call needs "country=0" to be sent for International OTP SMS to work.